### PR TITLE
adds `WebSocket::call(&self) -> &Call` method

### DIFF
--- a/src/api/websocket.rs
+++ b/src/api/websocket.rs
@@ -96,6 +96,10 @@ impl WebSocket {
         }
     }
 
+    pub fn call(&self) -> &Call {
+        &self.id
+    }
+
     pub fn empty() -> WebSocket {
         let mut r = Self::new(Call::empty(), Vec::new());
         r.state = State::Done;


### PR DESCRIPTION
Same as `SimpleCall::call` on `WebSocket`. Without this, it's impossible to retrieve the `CallRef` from a `WebSocket` instance directly.