### PR TITLE
Fix typo in comment and error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,8 +224,8 @@ pub enum Error {
     /// Eror while parsing chunked stream
     #[fail(display = "Error parsing WWW-Authenticate header")]
     AuthenticateParse,
-    /// Chunk was larger than configured CallBuilder::cunked_max_chunk.
-    #[fail(display = "Chunk was larger than configured CallBuilder::cunked_max_chunk. {}", _0)]
+    /// Chunk was larger than configured CallBuilder::chunked_max_chunk.
+    #[fail(display = "Chunk was larger than configured CallBuilder::chunked_max_chunk. {}", _0)]
     ChunkOverlimit(usize),
 }
 


### PR DESCRIPTION
I verified that the actuall function in src/api/builder.rs is named correctly, so this is only a typo in the comment and in the error message.