### PR TITLE
Fix compilation error in test case

### DIFF
--- a/src/resolve/cache.rs
+++ b/src/resolve/cache.rs
@@ -57,11 +57,12 @@ impl DnsCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
     use std::thread;
+    use smallvec::SmallVec;
 
-    fn ip(index: u8) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::new(127, 0, 0, index))
+    fn ip(index: u8) -> IpList {
+        SmallVec::from_vec(vec!(IpAddr::V4(Ipv4Addr::new(127, 0, 0, index))))
     }
 
     fn new_cache() -> DnsCache {


### PR DESCRIPTION
```
error[E0433]: failed to resolve. Use of undeclared type or module `IpAddr`                                                                                                                
  --> src/resolve/cache.rs:64:9                                                                                                                                                           
   |                                                                                                                                                                                      
64 |         IpAddr::V4(Ipv4Addr::new(127, 0, 0, index))                                                                                                                                  
   |         ^^^^^^ Use of undeclared type or module `IpAddr`                                                                                                                             
                                                                                                                                                                                          
error[E0412]: cannot find type `IpAddr` in this scope                                                                                                                                     
  --> src/resolve/cache.rs:63:25                                                                                                                                                          
   |                                                                                                                                                                                      
63 |     fn ip(index: u8) -> IpAddr {                                                                                                                                                     
   |                         ^^^^^^ did you mean `Ipv4Addr`?                                                                                                                              
help: possible candidate is found in another module, you can import it into scope                                                                                                         
   |                                                                                                                                                                                      
59 |     use std::net::IpAddr;                                                                                                                                                            
   |                                                                                                                                                                                      
                                                                                                                                                                                          
error: aborting due to 2 previous errors            
```                                                                                                                                      