### PR TITLE
Fix warning in rustls.rs

### DIFF
--- a/src/tls_api/rustls.rs
+++ b/src/tls_api/rustls.rs
@@ -399,7 +399,7 @@ impl TlsAcceptorBuilder {
             .into_iter()
             .map(|c| rustls::Certificate(c.to_vec()))
             .collect();
-        config.set_single_cert(certs, rustls::PrivateKey(key.to_vec()));
+        config.set_single_cert(certs, rustls::PrivateKey(key.to_vec()))?;
         Ok(TlsAcceptorBuilder(config))
     }
 }


### PR DESCRIPTION
config.set_single_cert(...) returns a Result, which should be checked.

(Or is it intentionally ignored? In that case, it could be done explicitly with `let _ = ...`, for documentation purposes and to silence the warning "unused `std::result::Result` which must be used" )