### PR TITLE
Fix Digest authentication issues

### DIFF
--- a/src/auth.pest
+++ b/src/auth.pest
@@ -18,4 +18,4 @@ opaque = { ^"opaque"  ~ "=" ~ qword}
 algorithm = { ^"algorithm" ~ "=" ~ alg}
 stale = { ^"stale" ~ "=" ~ bool}
 
-auth = { SOI ~ auth_type ~ ((realm | qop | nonce | opaque | algorithm) ~ ","?)+ ~ EOI }
+auth = { SOI ~ auth_type ~ ((realm | qop | nonce | opaque | algorithm | stale) ~ ","?)+ ~ EOI }

--- a/src/call.rs
+++ b/src/call.rs
@@ -453,6 +453,9 @@ impl CallImpl {
                     if self.b.chunked_parse && self.hdr_sz > 0 {
                         match ret {
                             Err(_) => {}
+                            // When RecvStateInt::DigestAuth is returned, Dir::Done is always self.dir.
+                            // So, the following arm is needed to avoid RecvStateInt::ReceivedBody.
+                            Ok(RecvStateInt::DigestAuth(_, _)) => {}
                             Ok(RecvStateInt::Response(_, _)) => {}
                             _ if b.is_some() && !self.b.gzip && Dir::Done != self.dir => {
                                 let b = b.unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -694,4 +694,14 @@ pub fn test_auth() {
     assert_eq!(da.nonce, "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v");
     assert_eq!(da.qop, DigestQop::Auth);
     assert_eq!(da.alg, DigestAlg::MD5Sess);
+    assert_eq!(da.stale, false);
+
+    let s = "Digest realm=\"http-auth@example.org\", nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\", stale=FALSE, qop=\"auth\"";
+    AuthParser::parse(Rule::auth, s).unwrap();
+    let da = AuthDigest::parse(s).unwrap();
+    assert_eq!(da.realm, "http-auth@example.org");
+    assert_eq!(da.nonce, "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v");
+    assert_eq!(da.qop, DigestQop::Auth);
+    assert_eq!(da.alg, DigestAlg::MD5);
+    assert_eq!(da.stale, false);
 }


### PR DESCRIPTION
I fixed issues about Digest authentication. Could you review this?

- Fixed parse error when `WWW-Authenticate` header has `stale`
    - I also add more patterns to `test_auth()`.
- Fixed Digest authentication when using `mio_httpc::Call`
    - Digest authentication works in `mi_httpc::SimpleCall`, but not in `mio_httpc::Call`, so I fixed.
    - I tested with my local HTTP server and modified `get_streaming.rs` example.