### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -992,7 +992,7 @@ impl ConTable {
             }
         }
         let mut con = usize::max_value();
-        for conid in cons.into_iter() {
+        for conid in cons.iter() {
             if *conid != usize::max_value() {
                 if self.cons[*conid].1.as_ref().is_some() {
                     con = *conid;


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
