### PR TITLE
Fix content length of post requests

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -192,7 +192,7 @@ impl CallImpl {
         if self.body_sz > 0 {
             // let mut ar = [0u8; 15];
             let mut sz = itoa::Buffer::new();
-            let szs = sz.format(self.b.port);
+            let szs = sz.format(self.b.body.len());
             buf.extend(b"Content-Length: ");
             buf.extend(szs.as_bytes());
             buf.extend(b"\r\n");


### PR DESCRIPTION
The size of the body is now used for the content-length header field. This field contained the port number and this was causing issues.