### PR TITLE
Remove spamming error log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 name = "mio_httpc"
 readme = "README.md"
 repository = "https://github.com/SergejJurecko/mio_httpc"
-version = "0.10.3"
+version = "0.10.4"
 
 [features]
 # Default does not work for https.

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -179,7 +179,6 @@ impl Dns {
 
                 builder.finish()
             };
-            eprintln!("DNS Send {:?}", &buf_send[..nsend]);
             let res = sock.send_to(&buf_send[..nsend], sockaddr);
             if let Ok(_) = res {
                 return Ok(true);


### PR DESCRIPTION
Feels like this was accidentally added with the version bump.