### PR TITLE
Fix max_redirects not working

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 name = "mio_httpc"
 readme = "README.md"
 repository = "https://github.com/SergejJurecko/mio_httpc"
-version = "0.10.4"
+version = "0.10.5"
 
 [features]
 # Default does not work for https.

--- a/src/httpc.rs
+++ b/src/httpc.rs
@@ -317,6 +317,8 @@ impl HttpcImpl {
                 call.invalidate();
                 if b.max_redirects > 0 {
                     b.max_redirects -= 1;
+                } else {
+                    return RecvState::Error(crate::Error::InvalidRedirect);
                 }
                 b.reused = true;
                 match Self::fix_location(&r, &mut b) {


### PR DESCRIPTION
The max_redirects parameter did not limit the number of redirects in any way.